### PR TITLE
typo in documentation

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -988,7 +988,7 @@ See the [filtering section](/filtering/).
 Logging
 -------
 
-rclone has 4 levels of logging, `Error`, `Notice`, `Info` and `Debug`.
+rclone has 4 levels of logging, `ERROR`, `NOTICE`, `INFO` and `DEBUG`.
 
 By default, rclone logs to standard error.  This means you can redirect
 standard error and still see the normal output of rclone commands (eg


### PR DESCRIPTION
change 4 log levels to all caps

https://github.com/ncw/rclone/issues/2101